### PR TITLE
Keep track of turn after game ends

### DIFF
--- a/flask-game/static/js/tic-tac-toe.js
+++ b/flask-game/static/js/tic-tac-toe.js
@@ -379,6 +379,10 @@ SuperTicTacToe.prototype.endGame = function () {
     this.bigModalMsg.innerHTML = `${this.currentBoard.modal.innerHTML} WINS 🎉`;
     this.bigModal.style.display = "block";
   });
+  if (this.superBoard.winner === "O") {
+    this.myTurn = !this.myTurn;
+    this.changeHighlightedPlayer();
+  }
   const exitButton = this.bigModal.querySelector("button");
   exitButton.addEventListener("click", () => {
     this.bigModal.style.display = "none";


### PR DESCRIPTION
We need to change turns after the game ends if "O" wins, so that the game will always start on player "X". 

TO DO:
- Handle case where the main game ends in a draw